### PR TITLE
fix: improved add modal logic

### DIFF
--- a/src/app/_components/LeaseModal.tsx
+++ b/src/app/_components/LeaseModal.tsx
@@ -58,30 +58,27 @@ export default function LeaseModal({
   const utils = reactClient.useUtils();
 
   const addModelMutation = reactClient.model.addModel.useMutation({
-    onSuccess: (gpus) => {
-      if (gpus > 8) {
-        toast.error(
-          "This model requires more than 8 GPUs, which exceeds our limit of 8 GPUs. We will not be able to run this model.",
-        );
-        return;
-      }
-      if (gpus === -1) {
-        toast.info("Model is already enabled and can be used immediately.");
+    onSuccess: (response) => {
+      // show message, then redirect to model page
+      if (response.enabled) {
+        toast.info(response.message);
         router.push(`/models/${encodeURIComponent(model)}`);
         return;
       }
-      if (gpus === -2) {
-        toast.info(
-          "Model requires a custom build. It has been marked for review by our team.",
-        );
+
+      // not enabled, custom build, show message
+      if (response.message) {
+        toast.info(response.message);
         return;
       }
 
+      // empty message is falsy
       toast.success("Model added successfully");
-      utils.model.getRequiredGpus.setData(model, gpus);
+      utils.model.getRequiredGpus.setData(model, response.gpus);
       setCurrentStep(currentStep + 1);
     },
     onError: (error) => {
+      // show error message
       toast.error("Failed to add model: " + error.message);
     },
   });

--- a/src/app/_components/LeaseModal.tsx
+++ b/src/app/_components/LeaseModal.tsx
@@ -70,6 +70,12 @@ export default function LeaseModal({
         router.push(`/models/${encodeURIComponent(model)}`);
         return;
       }
+      if (gpus === -2) {
+        toast.info(
+          "Model requires a custom build. It has been marked for review by our team.",
+        );
+        return;
+      }
 
       toast.success("Model added successfully");
       utils.model.getRequiredGpus.setData(model, gpus);

--- a/src/app/_components/settings/ActivityTab.tsx
+++ b/src/app/_components/settings/ActivityTab.tsx
@@ -38,9 +38,7 @@ export default function ActivityTab() {
                           ? activity.createdAt.toLocaleDateString()
                           : formatDate(activity.createdAt)}
                       </td>
-                      <td
-                        className="px-2 py-1 text-center leading-tight text-[#101828] max-w-40 truncate"
-                      >
+                      <td className="max-w-40 truncate px-2 py-1 text-center leading-tight text-[#101828]">
                         {activity.model}
                       </td>
                       <td className="px-2 py-1 text-center leading-tight text-[#101828]">

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -167,4 +167,5 @@ export const Model = mysqlTable("model", {
   description: text("description").default("No description provided"),
   supportedEndpoints: json("supported_endpoints").notNull().$type<string[]>(),
   enabledDate: timestamp("enabled_date", { mode: "date" }),
+  customBuild: boolean("custom_build").default(false).notNull(),
 });

--- a/src/server/api/model/index.ts
+++ b/src/server/api/model/index.ts
@@ -307,7 +307,7 @@ export const modelRouter = createTRPCRouter({
             cpt: 0,
             enabled: false,
             customBuild: true,
-            ...(description && { description }),
+            description: description ?? "No description provided",
           });
           return -2;
         }
@@ -357,7 +357,7 @@ export const modelRouter = createTRPCRouter({
         cpt: gpuData.required_gpus,
         enabled: false,
         customBuild: false,
-        ...(description && { description }),
+        description: description ?? "No description provided",
       });
 
       return gpuData.required_gpus;

--- a/src/server/stripeHandlers.ts
+++ b/src/server/stripeHandlers.ts
@@ -25,7 +25,7 @@ export const checkoutSuccess = async (
     .from(CheckoutSession)
     .where(eq(CheckoutSession.id, data.id));
   if (existing) {
-    return
+    return;
   }
 
   const line_items = await stripe.checkout.sessions.listLineItems(data.id);


### PR DESCRIPTION
Logic should now correctly handle:
- [x] Gated access checks
- [x] Library compatibility
- [x] Custom build requirements based on auto_map and transformersInfo
- [x] Different model architectures and configurations

Tested with:
1.) meta-llama/Llama-2-7b-chat-hf:
- Result: Returns early
- Why: Has gated: "manual" requiring Meta's approval
- Never reaches GPU estimation or custom build checks

2.) stabilityai/stable-diffusion-xl-base-1.0:
- Result: Rejected early
- Why: Has library_name: "diffusers" which isn't supported
- Throws BAD_REQUEST saying only transformers/timm are supported

3.)TinyLlama/TinyLlama-1.1B-Chat-v1.0:
- Result: customBuild: false
- Why: Has transformersInfo.auto_model: "AutoModelForCausalLM"
- Even without auto_map, it can use standard transformers classes

4.) NousResearch/Hermes-3-Llama-3.1-405B 
-  Result: returns error late
- Why: 20 gpus. Its huge
- Would pass GPU Estimation however
- Why: Not gated, has transofremersInfo.auto_model: "AutoModelForCausalLM"

Tested more but these are the ones i wrote down.